### PR TITLE
Update chalk, remove stripcolor

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
-printWidth: 120
-semi: false
-singleQuote: true
-trailingComma: "all"
+{
+  "printWidth": 120,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 module.exports = {
-  setupTestFrameworkScriptFile: "<rootDir>/src/__test__/init.ts",
-  mapCoverage: true,
+  setupFilesAfterEnv: ["<rootDir>/src/__test__/init.ts"],
   moduleFileExtensions: ['ts', 'js'],
   testMatch: ['**/*.test.ts'],
   transform: {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,12 @@
   "author": "Heroku",
   "bugs": "https://github.com/heroku/heroku-cli-color/issues",
   "dependencies": {
-    "ansi-styles": "^3.2.1",
-    "chalk": "^2.4.1",
-    "strip-ansi": "^5.0.0",
-    "supports-color": "^5.5.0",
+    "ansi-styles": "^4.3.0",
+    "chalk": "^4.1.2",
+    "supports-color": "^7.2.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@types/ansi-styles": "3.2.1",
     "@types/chalk": "2.2.0",
     "@types/jest": "^23.3.5",
     "@types/node": "14.18.63",
@@ -20,7 +18,7 @@
     "del-cli": "1.1.0",
     "jest": "^24.9.0",
     "lint-staged": "10.5.4",
-    "prettier": "^1.14.3",
+    "prettier": "^2.8.8",
     "ts-jest": "^24.3.0",
     "eslint": "^7.32.0",
     "typescript": "4.8.4"

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -32,8 +32,3 @@ test('app', () => {
 test('cannot set things', () => {
   expect(() => ((color as any).foo = 'bar')).toThrowError(/cannot set property foo/)
 })
-
-test('stripColor', () => {
-  expect(color.stripColor(color.red('foo'))).toEqual('foo')
-  expect(util.deprecate).toBeCalled()
-})

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,11 +1,7 @@
 import * as ansiStyles from 'ansi-styles'
-import chalk from 'chalk'
 import * as supports from 'supports-color'
-import { deprecate } from 'util'
 
-let stripColor = (s: string): string => {
-  return require('strip-ansi')(s)
-}
+const chalk = require('chalk');
 
 const dim = process.env.ConEmuANSI === 'ON' ? chalk.gray : chalk.dim
 
@@ -22,7 +18,6 @@ export const CustomColors: {
   pipeline: (s: string) => string
   app: (s: string) => string
   heroku: (s: string) => string
-  stripColor: (s: string) => string
 } = {
   supports,
   // map gray -> dim because it's not solarized compatible
@@ -35,17 +30,13 @@ export const CustomColors: {
   release: chalk.blue.bold,
   cmd: chalk.cyan.bold,
   pipeline: chalk.green.bold,
-  app: (s: string) => chalk.enabled ? color.heroku(`⬢ ${s}`) : s,
+  app: (s: string) => chalk.level > 0 ? color.heroku(`⬢ ${s}`) : s,
   heroku: (s: string) => {
-    if (!chalk.enabled) return s
+    if (chalk.level === 0) return s
     if (!color.supports) return s
     let has256 = color.supportsColor.has256 || (process.env.TERM || '').indexOf('256') !== -1
     return has256 ? '\u001b[38;5;104m' + s + ansiStyles.reset.open : chalk.magenta(s)
   },
-  stripColor: deprecate(
-    stripColor,
-    '.stripColor is deprecated. Please import the "strip-ansi" module directly instead.',
-  ),
 }
 
 export const color: typeof CustomColors & typeof chalk = new Proxy(chalk, {
@@ -53,10 +44,10 @@ export const color: typeof CustomColors & typeof chalk = new Proxy(chalk, {
     if ((CustomColors as any)[name]) return (CustomColors as any)[name]
     return (chalk as any)[name]
   },
-  set: (chalk, name, value) => {
+  set: (chalk, name) => {
     switch (name) {
       case 'enabled':
-        chalk.enabled = value
+        chalk.level = 2
         break
       default:
         throw new Error(`cannot set property ${name.toString()}`)

--- a/src/color.ts
+++ b/src/color.ts
@@ -44,10 +44,11 @@ export const color: typeof CustomColors & typeof chalk = new Proxy(chalk, {
     if ((CustomColors as any)[name]) return (CustomColors as any)[name]
     return (chalk as any)[name]
   },
-  set: (chalk, name) => {
+  set: (chalk, name, value) => {
     switch (name) {
       case 'enabled':
-        chalk.level = 2
+        if (value) chalk.level = 2
+        else chalk.level = 0
         break
       default:
         throw new Error(`cannot set property ${name.toString()}`)

--- a/test/strip.ts
+++ b/test/strip.ts
@@ -1,5 +1,4 @@
-import color from '../src'
+import color from '../src/color'
 
 const output = color.red('foo')
 console.log(`red ${output}`)
-console.log(`strip ${color.stripColor(output)}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -431,13 +431,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@types/ansi-styles@3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@types/ansi-styles/-/ansi-styles-3.2.1.tgz#49e996bb6e0b7957ca831205df31eb9a0702492c"
-  integrity sha512-UFa7mfKgSutXdT+elzJo8Ulr7FHgLNAyglVIOZYXFNJVQERm8DPrcwPret5BYk66LBE7fwm1XoVGi76MJkQ6ow==
-  dependencies:
-    "@types/color-name" "*"
-
 "@types/babel__core@^7.1.0":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -477,11 +470,6 @@
   integrity sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==
   dependencies:
     chalk "*"
-
-"@types/color-name@*":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.0.tgz#926f76f7e66f49cc59ad880bb15b030abbf0b66d"
-  integrity sha512-gZ/Rb+MFXF0pXSEQxdRoPMm5jeO3TycjOdvbpbcpHX/B+n9AqaHFe5q6Ga9CsZ7ir/UgIWPfrBzUzn3F19VH/w==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.6"
@@ -668,7 +656,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -1032,15 +1020,6 @@ chalk@*, chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1050,7 +1029,7 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3873,10 +3852,10 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@^1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
-  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^24.9.0:
   version "24.9.0"
@@ -4609,13 +4588,6 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
 supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
@@ -4623,7 +4595,7 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==


### PR DESCRIPTION
Collection of updates to address dependabots. This:
* Updates chalk. Requires some small API changes as chalk changed some things
* Removes `stripColor` from the heroku color package, rendering `stripAnsi` unnecessary as a dependency. `stripColor` has been "deprecated" for about 6 years. I think we can safely remove it at this point.
* Bumps to `ansi-styles` and `supports-color`, two other chalk packages
* Fixes to `prettier` while also bumping its version