### PR TITLE
chore: align workflows and release config with standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,34 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  open-pull-requests-limit: 5
-  schedule:
-      interval: "weekly"
-      time: "12:00"
-      day: "sunday"
-      timezone: "America/Los_Angeles"
-  commit-message:
-      prefix: "deps"
-- package-ecosystem: "npm"
-  directory: "/"
-  open-pull-requests-limit: 5
-  schedule:
-      interval: "weekly"
-      time: "12:00"
-      day: "sunday"
-      timezone: "America/Los_Angeles"
-  commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
-      include: "scope"
-  groups:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    open-pull-requests-limit: 5
+    schedule:
+      interval: 'weekly'
+      time: '12:00'
+      day: 'sunday'
+      timezone: 'America/Los_Angeles'
+    commit-message:
+      prefix: 'deps(dev)'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    open-pull-requests-limit: 5
+    schedule:
+      interval: 'weekly'
+      time: '12:00'
+      day: 'sunday'
+      timezone: 'America/Los_Angeles'
+    commit-message:
+      prefix: 'deps'
+      prefix-development: 'deps(dev)'
+    groups:
       dev-patch-minor-dependencies:
-        dependency-type: "development"
+        dependency-type: 'development'
         update-types:
-          - "patch"
-          - "minor"
-  ignore:
-    - dependency-name: "@oclif/core"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "typescript"
-      update-types: ["version-update:semver-major"]
+          - 'patch'
+          - 'minor'
+    ignore:
+      - dependency-name: '@oclif/core'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']

--- a/.github/release-configs/release-please-config.beta.json
+++ b/.github/release-configs/release-please-config.beta.json
@@ -8,7 +8,27 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "prerelease": true,
-      "prerelease-type": "beta"
+      "prerelease-type": "beta",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        {
+          "type": "deps",
+          "scope": "dev",
+          "section": "Dependencies",
+          "hidden": true
+        },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",

--- a/.github/release-configs/release-please-config.json
+++ b/.github/release-configs/release-please-config.json
@@ -6,7 +6,27 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": ["README.md"],
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        {
+          "type": "deps",
+          "scope": "dev",
+          "section": "Dependencies",
+          "hidden": true
+        },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,44 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows Conventional Commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "Checking PR title: $PR_TITLE"
+
+          # Define allowed types
+          ALLOWED_TYPES="feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert|deps"
+
+          # Check if title matches conventional commit format
+          # Format: type(scope)?: description or type(scope)!: description
+          if echo "$PR_TITLE" | grep -qE "^($ALLOWED_TYPES)(\(.+\))?!?: .+$"; then
+            echo "✅ PR title follows Conventional Commits format"
+
+            # Check that subject doesn't start with uppercase
+            SUBJECT=$(echo "$PR_TITLE" | sed -E "s/^($ALLOWED_TYPES)(\(.+\))?!?: //")
+            if echo "$SUBJECT" | grep -qE "^[A-Z]"; then
+              echo "❌ Error: Subject should not start with an uppercase character"
+              echo "Subject: $SUBJECT"
+              exit 1
+            fi
+
+            echo "✅ All checks passed"
+          else
+            echo "❌ Error: PR title does not follow Conventional Commits format"
+            echo "Expected format: type(scope)?: description"
+            echo "Examples:"
+            echo "  - feat: add new feature"
+            echo "  - fix(api): resolve bug in endpoint"
+            echo "  - chore!: breaking change"
+            echo ""
+            echo "Allowed types: feat, fix, chore, docs, style, refactor, perf, test, build, ci, revert, deps"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Add `.github/workflows/pr-title-check.yml` to enforce Conventional Commits on PR titles (with lowercase subject check)
- Reformat `.github/dependabot.yml` (2-space indent, single quotes) and switch dev-dependency commit prefix to `deps(dev)`
- Add `changelog-sections` config to both release-please configs so `feat`/`fix`/`perf`/`revert`/`deps`/`refactor` render as named CHANGELOG sections and `deps(dev)`, `docs`, `style`, `chore`, `test`, `build`, `ci` are hidden

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
Configuration-only changes; validated by CI.

**Steps**:
1. Passing CI suffices.
2. On merge, verify next dependabot PR uses the `deps(dev)` prefix for dev dependencies.
3. On next release, verify CHANGELOG groups entries under the configured sections.

## Screenshots (if applicable)

## Related Issues
GitHub issue: #N/A
GUS work item: N/A